### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you're using [Homebrew Cask](https://caskroom.github.io), you can install it 
 
 ```bash
 brew update
-brew cask install now
+brew install --cask now
 ```
 
 ## Caught a bug?


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524